### PR TITLE
fix(haspermissions): carry missingPermissions array on resolvers

### DIFF
--- a/lib/hasPermissions.ts
+++ b/lib/hasPermissions.ts
@@ -229,6 +229,21 @@ export class HasPermissionsDirectiveVisitor<
       ) {
         throw new ForbiddenError(getErrorMessage(missingPermissions));
       }
+      /*
+        If any missing permissions existed from other hasPermissions that
+        were executed before it, then pass or extend that array with the new
+        permissions
+      */
+      const existingMissingPermissions = args[missingPermissionsArgumentName];
+      if (existingMissingPermissions) {
+        if (!missingPermissions) {
+          missingPermissions = existingMissingPermissions;
+        } else {
+          missingPermissions = missingPermissions.concat(
+            existingMissingPermissions,
+          );
+        }
+      }
 
       const enhancedArgs = {
         ...args,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profusion/apollo-validation-directives",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "GraphQL directives to implement field validations in Apollo Server",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",


### PR DESCRIPTION
Give the following schema:

type MyType @hasPermissions(permissions: ["x"]) {
  id: ID!
  someField: String @hasPermissions(permissions: ["y"], policy: RESOLVER)
}

The hasPermissions directive would not correcly pass the missingPermissions
array with the "y" permission in case the user did not have the permissions.

This was happening, because the resolver function was considering that it might
be wrapped. In order to prevent such errors the resolver will always
concat the previous missingPermissions array to the next resolver.