### PR TITLE
feat: add selfNodeId and foreignNodeId directives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
     },
     "plugins": [
         "@typescript-eslint",
-        "filenames",
         "import"
     ],
     "parser": "@typescript-eslint/parser",
@@ -46,18 +45,6 @@
             {
                 "argsIgnorePattern": "^_"
             }
-        ],
-        "filenames/match-exported": [
-            "error",
-            [
-                null,
-                "kebab"
-            ]
-        ],
-        "filenames/match-regex": [
-            "error",
-            "^[a-zA-Z]+(-[a-z]+)*(\\.[a-z]+)?$",
-            true
         ],
         "func-names": [
             2,

--- a/lib/ValidateDirectiveVisitor.ts
+++ b/lib/ValidateDirectiveVisitor.ts
@@ -509,7 +509,7 @@ const wrapFieldResolverValidateArgument = <TContext>(
 // If this function is called multiple times for the same field
 // the validation will be chained:
 // validate(previousValidation(resolvedValue))`
-const wrapFieldResolverResult = <TContext>(
+export const wrapFieldResolverResult = <TContext>(
   field: GraphQLField<unknown, TContext>,
   validate: ValidateFunction<TContext>,
   objectType: GraphQLObjectType,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import { AuthenticationError } from 'apollo-server-errors';
 
 import {

--- a/lib/foreignNodeId.test.ts
+++ b/lib/foreignNodeId.test.ts
@@ -1,0 +1,245 @@
+import { graphql } from 'graphql';
+import { print } from 'graphql/language/printer';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { ValidationError } from 'apollo-server-errors';
+
+import { ValidateFunction } from './ValidateDirectiveVisitor';
+import ForeignNodeIdDirective, {
+  ForeignNodeIdContext,
+  ToNodeId,
+} from './foreignNodeId';
+
+describe('@foreignNodeId()', (): void => {
+  const toNodeId = (typenane: string, id: string): string =>
+    Buffer.from(`${typenane}:${id}`).toString('base64');
+  const fromNodeId = (id: string): ReturnType<ToNodeId<string>> => {
+    const r = Buffer.from(id, 'base64')
+      .toString('ascii')
+      .split(':');
+    return {
+      id: r[1],
+      typename: r[0],
+    };
+  };
+  const name = 'foreignNodeId';
+  const directiveTypeDefs = ForeignNodeIdDirective.getTypeDefs(name);
+
+  it('exports correct typeDefs', (): void => {
+    expect(directiveTypeDefs.map(print)).toEqual([
+      `\
+"""Converts a global unique ID to a type ID"""
+directive @${name}(
+  """The typename that this ID should match"""
+  typename: String!
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+`,
+    ]);
+  });
+
+  it('defaultName is correct', (): void => {
+    expect(directiveTypeDefs.map(print)).toEqual(
+      ForeignNodeIdDirective.getTypeDefs().map(print),
+    );
+  });
+
+  it('createDirectiveContext()', (): void => {
+    const ctx = ForeignNodeIdDirective.createDirectiveContext({
+      fromNodeId,
+    });
+    expect(ctx.fromNodeId).toBe(fromNodeId);
+  });
+
+  it('should not work if fromNodeId returns null', async (): Promise<void> => {
+    const typename = 'X';
+    const schema = ForeignNodeIdDirective.addValidationResolversToSchema(
+      makeExecutableSchema({
+        schemaDirectives: {
+          foreignNodeId: ForeignNodeIdDirective,
+        },
+        typeDefs: [
+          ...directiveTypeDefs,
+          gql`
+            type Query {
+              work(arg: ID! @foreignNodeId(typename: "${typename}")): Boolean
+            }
+          `,
+        ],
+      }),
+    );
+    const source = print(gql`
+      query MyQuery($arg: ID!) {
+        work(arg: $arg)
+      }
+    `);
+    const variables = {
+      arg: '1',
+    };
+    const context = ForeignNodeIdDirective.createDirectiveContext({
+      fromNodeId: () => null,
+    });
+    const result = await graphql(schema, source, null, context, variables);
+    expect(result).toEqual({
+      data: { work: null },
+      errors: [new ValidationError(`Could not decode ID to ${typename}`)],
+    });
+  });
+
+  it('should not work on non string types', async (): Promise<void> => {
+    const schema = ForeignNodeIdDirective.addValidationResolversToSchema(
+      makeExecutableSchema({
+        schemaDirectives: {
+          foreignNodeId: ForeignNodeIdDirective,
+        },
+        typeDefs: [
+          ...directiveTypeDefs,
+          gql`
+            input Input1 {
+              typeId: Int! @foreignNodeId(typename: "A")
+            }
+            type Query {
+              work(input: Input1!): Boolean
+            }
+          `,
+        ],
+      }),
+    );
+    const source = print(gql`
+      query MyQuery($input: Input1!) {
+        work(input: $input)
+      }
+    `);
+    const variables = {
+      input: {
+        typeId: 1,
+      },
+    };
+    const context = ForeignNodeIdDirective.createDirectiveContext({
+      fromNodeId,
+    });
+    const result = await graphql(schema, source, null, context, variables);
+    expect(result).toEqual({
+      data: { work: null },
+      errors: [
+        new ValidationError('foreignNodeId directive only works on strings'),
+      ],
+    });
+  });
+
+  it('typename does not match', async (): Promise<void> => {
+    const wrongName = 'wrong';
+    const typename = 'typename';
+    const schema = ForeignNodeIdDirective.addValidationResolversToSchema(
+      makeExecutableSchema({
+        schemaDirectives: {
+          foreignNodeId: ForeignNodeIdDirective,
+        },
+        typeDefs: [
+          ...directiveTypeDefs,
+          gql`
+            type Query {
+              work(arg: ID! @foreignNodeId(typename: "${typename}")): Boolean
+            }
+          `,
+        ],
+      }),
+    );
+    const source = print(gql`
+      query MyQuery($arg: ID!) {
+        work(arg: $arg)
+      }
+    `);
+    const variables = {
+      arg: toNodeId(wrongName, '1'),
+    };
+    const context = ForeignNodeIdDirective.createDirectiveContext({
+      fromNodeId,
+    });
+    const result = await graphql(schema, source, null, context, variables);
+    expect(result).toEqual({
+      data: { work: null },
+      errors: [
+        new ValidationError(
+          `Converted ID typename does not match. Expected: ${typename}`,
+        ),
+      ],
+    });
+  });
+
+  it('correctly convert types', async (): Promise<void> => {
+    const idsMap = [
+      { id: 'bbb', typeName: 'Type1' },
+      { id: 'id2', typeName: 'Type2' },
+      { id: 'id3', typeName: 'Type3' },
+      { id: 'id4', typeName: 'Type4' },
+      { id: 'aaaaa', typeName: 'Type5' },
+    ];
+    const jestMocks: jest.Mock[] = [];
+    class TestDirective extends ForeignNodeIdDirective<
+      string,
+      ForeignNodeIdContext
+    > {
+      public getValidationForArgs():
+        | ValidateFunction<ForeignNodeIdContext>
+        | undefined {
+        const func = super.getValidationForArgs();
+        if (func) {
+          const mock = jest.fn(func);
+          jestMocks.push(mock);
+          return mock;
+        }
+        return undefined;
+      }
+    }
+    const schema = TestDirective.addValidationResolversToSchema(
+      makeExecutableSchema({
+        schemaDirectives: {
+          foreignNodeId: TestDirective,
+        },
+        typeDefs: [
+          ...directiveTypeDefs,
+          gql`
+            input Input1 {
+              typeId: ID! @foreignNodeId(typename: "${idsMap[1].typeName}")
+              typeId2: ID! @foreignNodeId(typename: "${idsMap[2].typeName}")
+              typeId3: ID! @foreignNodeId(typename: "${idsMap[3].typeName}")
+              typeId4: String! @foreignNodeId(typename: "${idsMap[4].typeName}")
+            }
+            type Query {
+              work(
+                input: Input1!
+                arg: ID! @foreignNodeId(typename: "${idsMap[0].typeName}")
+              ): Boolean
+            }
+          `,
+        ],
+      }),
+    );
+    const source = print(gql`
+      query MyQuery($input: Input1!, $arg: ID!) {
+        work(input: $input, arg: $arg)
+      }
+    `);
+    const variables = {
+      arg: toNodeId(idsMap[0].typeName, idsMap[0].id),
+      input: {
+        typeId: toNodeId(idsMap[1].typeName, idsMap[1].id),
+        typeId2: toNodeId(idsMap[2].typeName, idsMap[2].id),
+        typeId3: toNodeId(idsMap[3].typeName, idsMap[3].id),
+        typeId4: toNodeId(idsMap[4].typeName, idsMap[4].id),
+      },
+    };
+    const rootValue = {
+      work: true,
+    };
+
+    const context = ForeignNodeIdDirective.createDirectiveContext({
+      fromNodeId,
+    });
+    const result = await graphql(schema, source, rootValue, context, variables);
+    expect(result).toEqual({ data: rootValue });
+    jestMocks.forEach(({ mock: { results } }, i): void => {
+      expect(results[0].value).toEqual(idsMap[i].id);
+    });
+  });
+});

--- a/lib/hasPermissions.ts
+++ b/lib/hasPermissions.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import { ForbiddenError } from 'apollo-server-errors';
 import {
   defaultFieldResolver,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,3 +13,5 @@ export { default as listLength } from './listLength';
 export { default as pattern } from './pattern';
 export { default as range } from './range';
 export { default as stringLength } from './stringLength';
+export { default as selfNodeId } from './selfNodeId';
+export { default as foreignNodeId } from './foreignNodeId';

--- a/lib/selfNodeId.test.ts
+++ b/lib/selfNodeId.test.ts
@@ -1,0 +1,227 @@
+import { graphql } from 'graphql';
+import { print } from 'graphql/language/printer';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+import { ValidationError } from 'apollo-server-errors';
+
+import SelfNodeId from './selfNodeId';
+
+const toNodeId = (name: string, id: string): string =>
+  Buffer.from(`${name}:${id}`).toString('base64');
+
+describe('@selfNodeId()', (): void => {
+  const name = 'selfNodeId';
+  const directiveTypeDefs = SelfNodeId.getTypeDefs(name);
+
+  it('exports correct typeDefs', (): void => {
+    expect(directiveTypeDefs.map(print)).toEqual([
+      `\
+"""ensures that the ID is converted to a global ID"""
+directive @${name} on FIELD_DEFINITION | OBJECT
+`,
+    ]);
+  });
+
+  it('defaultName is correct', (): void => {
+    expect(directiveTypeDefs.map(print)).toEqual(
+      SelfNodeId.getTypeDefs().map(print),
+    );
+  });
+
+  describe('createDirectiveContext()', (): void => {
+    it('supports function', (): void => {
+      const ctx = SelfNodeId.createDirectiveContext({
+        toNodeId,
+      });
+      expect(ctx.toNodeId).toBe(toNodeId);
+    });
+  });
+
+  describe('fails on object definition', (): void => {
+    it('ID field not provided', async (): Promise<void> => {
+      expect.assertions(1);
+      const typeName = 'TypeWithNoId';
+      expect(() =>
+        SelfNodeId.addValidationResolversToSchema(
+          makeExecutableSchema({
+            schemaDirectives: {
+              selfNodeId: SelfNodeId,
+            },
+            typeDefs: [
+              ...directiveTypeDefs,
+              gql`
+                type ${typeName} @selfNodeId {
+                  field: ID!
+                  anotherField: Float
+                }
+                type Query {
+                  test: ${typeName}
+                }
+              `,
+            ],
+          }),
+        ),
+      ).toThrow(new ValidationError(`id field was not found in ${typeName}`));
+    });
+  });
+
+  describe('works on field and object definitions', (): void => {
+    const type1 = 'Type1';
+    const type2 = 'Type2';
+    const type4 = 'Type4';
+    const type1Id = 'ThisIsAnId';
+    const type2Id = 'ThisIsAnotherId';
+    const type4Id = 'type4Id';
+    const schema = SelfNodeId.addValidationResolversToSchema(
+      makeExecutableSchema({
+        schemaDirectives: {
+          selfNodeId: SelfNodeId,
+        },
+        typeDefs: [
+          ...directiveTypeDefs,
+          gql`
+          type ${type1} {
+            id: ID! @selfNodeId
+          }
+          type ${type2} {
+            id: ID! @selfNodeId
+          }
+          type Type3 {
+            id: ID!
+          }
+          type ${type4} @selfNodeId {
+            id: ID!
+            anotherField: Float!
+            yetAnotherField: String!
+          }
+          type ShouldFail {
+            float: Float @selfNodeId
+            array: [String] @selfNodeId
+          }
+          type Test {
+            type1: ${type1}
+            type2: ${type2}
+            type3: Type3
+            type4: ${type4}
+            shouldFail: ShouldFail
+          }
+          type Query {
+            test: Test
+          }
+        `,
+        ],
+      }),
+    );
+    const source = print(gql`
+      query {
+        test {
+          type1 {
+            id
+          }
+          type2 {
+            id
+          }
+          type3 {
+            id
+          }
+          type4 {
+            id
+            anotherField
+            yetAnotherField
+          }
+          shouldFail {
+            float
+            array
+          }
+        }
+      }
+    `);
+    const rootValue = {
+      test: {
+        shouldFail: {
+          array: ['1', '2'],
+          float: 2.3,
+        },
+        type1: {
+          id: type1Id,
+        },
+        type2: {
+          id: type2Id,
+        },
+        type3: {
+          id: '2',
+        },
+        type4: {
+          anotherField: 5.2,
+          id: type4Id,
+          yetAnotherField: 'asd',
+        },
+      },
+    };
+
+    it('Correctly converts to node ID', async (): Promise<void> => {
+      const context = SelfNodeId.createDirectiveContext({
+        toNodeId,
+      });
+      const result = await graphql(schema, source, rootValue, context);
+      expect(result).toEqual({
+        data: {
+          test: {
+            shouldFail: {
+              array: null,
+              float: null,
+            },
+            type1: {
+              id: toNodeId(type1, type1Id),
+            },
+            type2: {
+              id: toNodeId(type2, type2Id),
+            },
+            type3: {
+              id: rootValue.test.type3.id,
+            },
+            type4: {
+              anotherField: rootValue.test.type4.anotherField,
+              id: toNodeId(type4, type4Id),
+              yetAnotherField: rootValue.test.type4.yetAnotherField,
+            },
+          },
+        },
+        errors: [
+          new ValidationError('selfNodeId directive only works on strings'),
+          new ValidationError('selfNodeId directive only works on strings'),
+        ],
+      });
+    });
+
+    it('Correctly converts to node ID', async (): Promise<void> => {
+      const context = SelfNodeId.createDirectiveContext({
+        toNodeId: () => null,
+      });
+      const result = await graphql(schema, source, rootValue, context);
+      expect(result).toEqual({
+        data: {
+          test: {
+            shouldFail: {
+              array: null,
+              float: null,
+            },
+            type1: null,
+            type2: null,
+            type3: {
+              id: '2',
+            },
+            type4: null,
+          },
+        },
+        errors: [
+          new ValidationError('selfNodeId directive only works on strings'),
+          new ValidationError('selfNodeId directive only works on strings'),
+          new ValidationError(`Could not encode ID to typename ${type1}`),
+          new ValidationError(`Could not encode ID to typename ${type2}`),
+          new ValidationError(`Could not encode ID to typename ${type4}`),
+        ],
+      });
+    });
+  });
+});

--- a/lib/selfNodeId.ts
+++ b/lib/selfNodeId.ts
@@ -1,0 +1,65 @@
+import {
+  DirectiveLocation,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+} from 'graphql';
+import { ValidationError } from 'apollo-server-errors';
+
+import ValidateDirectiveVisitor, {
+  ValidateFunction,
+  wrapFieldResolverResult,
+} from './ValidateDirectiveVisitor';
+
+type ToNodeId = (entityName: string, id: string) => string | null;
+
+export type SelfNodeIdContext<TContext extends object = object> = {
+  toNodeId: ToNodeId;
+};
+
+export default class SelfNodeIdDirective<
+  TContext extends SelfNodeIdContext
+> extends ValidateDirectiveVisitor<{}, SelfNodeIdContext> {
+  public getValidationForArgs(): ValidateFunction<SelfNodeIdContext> {
+    const errorMessage = `${this.name} directive only works on strings`;
+    return (value: unknown, _, { name }, { toNodeId }): string => {
+      if (typeof value !== 'string') {
+        throw new ValidationError(errorMessage);
+      }
+      const encodedId = toNodeId(name, value);
+      if (!encodedId) {
+        throw new ValidationError(`Could not encode ID to typename ${name}`);
+      }
+      return encodedId;
+    };
+  }
+
+  public static readonly config: typeof ValidateDirectiveVisitor['config'] = {
+    description: 'ensures that the ID is converted to a global ID',
+    locations: [DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.OBJECT],
+  };
+
+  public visitObject(object: GraphQLObjectType | GraphQLInterfaceType): void {
+    const validate = this.getValidationForArgs();
+    let foundId = false;
+    const fields = Object.values(object.getFields());
+    for (let i = 0; i < fields.length; i += 1) {
+      const field = fields[i];
+      if (field.name === 'id') {
+        wrapFieldResolverResult(field, validate, object as GraphQLObjectType);
+        foundId = true;
+        break;
+      }
+    }
+    if (!foundId) {
+      throw new ValidationError(`id field was not found in ${object.name}`);
+    }
+  }
+
+  public static readonly defaultName: string = 'selfNodeId';
+
+  public static createDirectiveContext(ctx: {
+    toNodeId: ToNodeId;
+  }): SelfNodeIdContext {
+    return ctx;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-import-resolver-typescript": "^2.0.0",
-    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profusion/apollo-validation-directives",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "GraphQL directives to implement field validations in Apollo Server",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,16 +2202,6 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-filenames@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
-  integrity sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==
-  dependencies:
-    lodash.camelcase "4.3.0"
-    lodash.kebabcase "4.1.1"
-    lodash.snakecase "4.1.1"
-    lodash.upperfirst "4.3.1"
-
 eslint-plugin-import@^2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
@@ -4017,25 +4007,10 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.camelcase@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
-lodash.kebabcase@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
-  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
-
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.snakecase@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
-  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4056,11 +4031,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
-
-lodash.upperfirst@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
-  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
 lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"


### PR DESCRIPTION
These new directives will make it possible create unique
IDs for GraphQL APIs that follow the Relay's node interface
specification.