### PR TITLE
fix: do not try to validate input fields that are not present

### DIFF
--- a/lib/ValidateDirectiveVisitor.test.ts
+++ b/lib/ValidateDirectiveVisitor.test.ts
@@ -1382,8 +1382,20 @@ directive @${name}(
                 arg: [DeepNullableEntry]
                 validationErrors: [ValidatedInputErrorOutput!]
               }
+              input YetAnotherInput {
+                number: Int
+              }
+              input Args {
+                field: String!
+                moreInputs: YetAnotherInput
+              }
+              input NullableSubInput {
+                field1: Args
+                field2: Args
+              }
               input DeepNullableInput {
                 nullable: Int @${name}
+                nullable2: NullableSubInput
               }
               input NoValidatedFields {
                 # a validated argument without validated list arguments

--- a/lib/ValidateDirectiveVisitor.ts
+++ b/lib/ValidateDirectiveVisitor.ts
@@ -173,6 +173,7 @@ const validateContainerEntry = <TContext>(
   containerType: GraphQLArgument | GraphQLInputObjectType | GraphQLObjectType,
   context: TContext,
 ): void => {
+  if (!container) return;
   const originalValue = container[entry];
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const validatedValue = validateEntryValue(

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "apollo-server-errors": "^2.3.4",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
-    "graphql-tools": "^4.0.7"
+    "graphql-tools": "4.0.7"
   }
 }


### PR DESCRIPTION
This commit fixes a problem where the ValidateDirectiveVisitor
would try to visit an input that is not present, thus caused
an undefined deference.