### PR TITLE
fix: invalid value serialization when input property is not provided

### DIFF
--- a/lib/ValidateDirectiveVisitor.test.ts
+++ b/lib/ValidateDirectiveVisitor.test.ts
@@ -1396,6 +1396,8 @@ directive @${name}(
               input DeepNullableInput {
                 nullable: Int @${name}
                 nullable2: NullableSubInput
+                nullableString: String
+                nullableStringNotSet: String
               }
               input NoValidatedFields {
                 # a validated argument without validated list arguments
@@ -1418,7 +1420,7 @@ directive @${name}(
 
       const source = print(gql`
         query {
-          deepNullable(arg: [{ nullable: ${value} }], other: { list: [1] }) {
+          deepNullable(arg: [{ nullable: ${value}, nullableString: null }], other: { list: [1] }) {
             arg {
               nullable
             }

--- a/lib/ValidateDirectiveVisitor.ts
+++ b/lib/ValidateDirectiveVisitor.ts
@@ -173,6 +173,7 @@ const validateContainerEntry = <TContext>(
   containerType: GraphQLArgument | GraphQLInputObjectType | GraphQLObjectType,
   context: TContext,
 ): void => {
+  // istanbul ignore if  (shouldn't reach)
   if (!container) return;
   const originalValue = container[entry];
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -201,7 +202,6 @@ const validateFieldArguments = <TContext>(
   const path: string[] = [];
   const errors: ValidatedInputError[] =
     args[validationErrorsArgumentName] || [];
-
   definitions.forEach((arg: ValidatedGraphQLArgument<TContext>): void => {
     const { name, type, validation } = arg;
     validateContainerEntry(
@@ -317,8 +317,8 @@ const validateEntryValueThrowing = <TContext>(
     type = type.ofType;
   }
 
-  if (value === null) {
-    return null;
+  if (value === null || value === undefined) {
+    return value;
   }
 
   if (type instanceof GraphQLInputObjectType) {


### PR DESCRIPTION
When an input property is not provided its value won't be set to null,
it will be set to undefined. This would cause the ValidateDirectiveVisitor
to try to serialize the value or in case of more complex types, try to
validate it as well.
In order to avoid these cases, undefined must also be tested.

Closes #10