### PR TITLE
feat: add policy argument to ValdiateDirectiveVisitor

### DIFF
--- a/lib/createValidateDirectiveVisitor.test.ts
+++ b/lib/createValidateDirectiveVisitor.test.ts
@@ -95,6 +95,10 @@ describe('createValidateDirectiveVisitor', (): void => {
     expect(directive.config).toEqual({
       ...ValidateDirectiveVisitor.config,
       ...directiveConfig,
+      args: {
+        ...directiveConfig.args,
+        ...ValidateDirectiveVisitor.config.args,
+      },
     });
 
     const result = await graphql(schema, '{ item list }', rootValue);

--- a/lib/createValidateDirectiveVisitor.ts
+++ b/lib/createValidateDirectiveVisitor.ts
@@ -1,5 +1,6 @@
 import ValidateDirectiveVisitor, {
   ValidateFunction,
+  ValidationDirectiveArgs,
 } from './ValidateDirectiveVisitor';
 import validateArrayOrValue from './validateArrayOrValue';
 
@@ -8,7 +9,7 @@ export type CreateValidate<TArgs extends object> = (
 ) => ValidateFunction | undefined;
 
 export class ConcreteValidateDirectiveVisitor<
-  TArgs extends object
+  TArgs extends ValidationDirectiveArgs
 > extends ValidateDirectiveVisitor<TArgs> {
   // istanbul ignore next (this shouldn't be used)
   // eslint-disable-next-line class-methods-use-this
@@ -19,7 +20,7 @@ export class ConcreteValidateDirectiveVisitor<
   }
 }
 
-const createValidateDirectiveVisitor = <TArgs extends object>({
+const createValidateDirectiveVisitor = <TArgs extends ValidationDirectiveArgs>({
   createValidate,
   defaultName,
   directiveConfig,
@@ -43,6 +44,10 @@ const createValidateDirectiveVisitor = <TArgs extends object>({
       ? ({
           ...ValidateDirectiveVisitor.config,
           ...directiveConfig,
+          args: {
+            ...directiveConfig.args,
+            ...ValidateDirectiveVisitor.config.args,
+          },
         } as const)
       : ValidateDirectiveVisitor.config;
 

--- a/lib/foreignNodeId.ts
+++ b/lib/foreignNodeId.ts
@@ -3,6 +3,7 @@ import { ValidationError } from 'apollo-server-errors';
 
 import ValidateDirectiveVisitor, {
   ValidateFunction,
+  ValidationDirectiveArgs,
 } from './ValidateDirectiveVisitor';
 import validateArrayOrValue from './validateArrayOrValue';
 
@@ -19,7 +20,7 @@ export type ForeignNodeIdContext<
 
 export type Args = {
   typename: string;
-};
+} & ValidationDirectiveArgs;
 
 export default class ForeignNodeIdDirective<
   IdType,

--- a/lib/listLength.test.ts
+++ b/lib/listLength.test.ts
@@ -8,6 +8,7 @@ import {
   CreateSchemaConfig,
   ExpectedTestResult,
   testEasyDirective,
+  validationDirectivePolicyArgs,
 } from './test-utils.test';
 
 type RootValue = {
@@ -51,6 +52,7 @@ testEasyDirective({
   max: Float = null
   """The minimum list length (inclusive) to allow. If null, no lower limit is applied"""
   min: Float = null
+  ${validationDirectivePolicyArgs}
 )`,
   name: 'listLength',
   testCases: [

--- a/lib/listLength.ts
+++ b/lib/listLength.ts
@@ -1,7 +1,10 @@
 import { GraphQLFloat } from 'graphql';
 import { ValidationError } from 'apollo-server-errors';
 
-import { ValidateFunction } from './ValidateDirectiveVisitor';
+import {
+  ValidateFunction,
+  ValidationDirectiveArgs,
+} from './ValidateDirectiveVisitor';
 import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
 
 const createValidateMinMax = (min: number, max: number): ValidateFunction => {
@@ -45,7 +48,7 @@ const createValidateMax = (max: number): ValidateFunction => {
 type ListLengthDirectiveArgs = {
   min: number | null;
   max: number | null;
-};
+} & ValidationDirectiveArgs;
 
 // istanbul ignore next (args set by default to null)
 const createValidate = ({

--- a/lib/pattern.test.ts
+++ b/lib/pattern.test.ts
@@ -8,6 +8,7 @@ import {
   CreateSchemaConfig,
   ExpectedTestResult,
   testEasyDirective,
+  validationDirectivePolicyArgs,
 } from './test-utils.test';
 
 type RootValue = {
@@ -60,7 +61,11 @@ testEasyDirective({
   createSchema,
   DirectiveVisitor: pattern,
   expectedArgsTypeDefs: `\
-(flags: String, regexp: String!)`,
+(
+  flags: String
+  regexp: String!
+  ${validationDirectivePolicyArgs}
+)`,
   name: 'pattern',
   testCases: [
     {

--- a/lib/pattern.ts
+++ b/lib/pattern.ts
@@ -2,7 +2,10 @@ import { ValidationError } from 'apollo-server-errors';
 
 import { GraphQLNonNull, GraphQLString } from 'graphql';
 
-import { ValidateFunction } from './ValidateDirectiveVisitor';
+import {
+  ValidateFunction,
+  ValidationDirectiveArgs,
+} from './ValidateDirectiveVisitor';
 import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
 
 const validatePattern = (
@@ -33,7 +36,7 @@ const validatePattern = (
 type PatternDirectiveArgs = {
   regexp: string;
   flags?: string | null;
-};
+} & ValidationDirectiveArgs;
 
 const createValidate = ({
   regexp,

--- a/lib/range.test.ts
+++ b/lib/range.test.ts
@@ -8,6 +8,7 @@ import {
   CreateSchemaConfig,
   ExpectedTestResult,
   testEasyDirective,
+  validationDirectivePolicyArgs,
 } from './test-utils.test';
 
 type RootValue = {
@@ -51,6 +52,7 @@ testEasyDirective({
   max: Float = null
   """The minimum value (inclusive) to allow. If null, no lower limit is applied"""
   min: Float = null
+  ${validationDirectivePolicyArgs}
 )`,
   name: 'range',
   testCases: [

--- a/lib/range.ts
+++ b/lib/range.ts
@@ -1,7 +1,10 @@
 import { GraphQLFloat } from 'graphql';
 import { ValidationError } from 'apollo-server-errors';
 
-import { ValidateFunction } from './ValidateDirectiveVisitor';
+import {
+  ValidateFunction,
+  ValidationDirectiveArgs,
+} from './ValidateDirectiveVisitor';
 import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
 
 const createValidateMinMax = (min: number, max: number): ValidateFunction => {
@@ -41,7 +44,7 @@ const createValidateMax = (max: number): ValidateFunction => {
 type RangeDirectiveArgs = {
   min: number | null;
   max: number | null;
-};
+} & ValidationDirectiveArgs;
 
 // istanbul ignore next (args set by default to null)
 const createValidate = ({

--- a/lib/selfNodeId.ts
+++ b/lib/selfNodeId.ts
@@ -8,6 +8,7 @@ import { ValidationError } from 'apollo-server-errors';
 import ValidateDirectiveVisitor, {
   ValidateFunction,
   wrapFieldResolverResult,
+  ValidationDirectiveArgs,
 } from './ValidateDirectiveVisitor';
 
 type ToNodeId = (entityName: string, id: string) => string | null;
@@ -18,7 +19,7 @@ export type SelfNodeIdContext<TContext extends object = object> = {
 
 export default class SelfNodeIdDirective<
   TContext extends SelfNodeIdContext
-> extends ValidateDirectiveVisitor<{}, SelfNodeIdContext> {
+> extends ValidateDirectiveVisitor<ValidationDirectiveArgs, SelfNodeIdContext> {
   public getValidationForArgs(): ValidateFunction<SelfNodeIdContext> {
     const errorMessage = `${this.name} directive only works on strings`;
     return (

--- a/lib/stringLength.test.ts
+++ b/lib/stringLength.test.ts
@@ -8,6 +8,7 @@ import {
   CreateSchemaConfig,
   ExpectedTestResult,
   testEasyDirective,
+  validationDirectivePolicyArgs,
 } from './test-utils.test';
 
 type RootValue = {
@@ -51,6 +52,7 @@ testEasyDirective({
   max: Float = null
   """The minimum string length (inclusive) to allow. If null, no lower limit is applied"""
   min: Float = null
+  ${validationDirectivePolicyArgs}
 )`,
   name: 'stringLength',
   testCases: [

--- a/lib/stringLength.ts
+++ b/lib/stringLength.ts
@@ -1,7 +1,10 @@
 import { GraphQLFloat } from 'graphql';
 import { ValidationError } from 'apollo-server-errors';
 
-import { ValidateFunction } from './ValidateDirectiveVisitor';
+import {
+  ValidateFunction,
+  ValidationDirectiveArgs,
+} from './ValidateDirectiveVisitor';
 import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
 
 const createValidateMinMax = (min: number, max: number): ValidateFunction => {
@@ -45,7 +48,7 @@ const createValidateMax = (max: number): ValidateFunction => {
 type StringLengthDirectiveArgs = {
   min: number | null;
   max: number | null;
-};
+} & ValidationDirectiveArgs;
 
 // istanbul ignore next (args set by default to null)
 const createValidate = ({

--- a/lib/test-utils.test.ts
+++ b/lib/test-utils.test.ts
@@ -45,17 +45,30 @@ export type TestCase<TValue, TResult = ExecutionResultDataDefault> = {
   }[];
 };
 
+export const validationDirectionEnumTypeDefs = `\
+enum ValidateDirectivePolicy {
+  """Field resolver is responsible to evaluate it using \`validationErrors\` injected in GraphQLResolverInfo"""
+  RESOLVER
+  """Field resolver is not called if occurs a validation error, it throws \`UserInputError\`"""
+  THROW
+}`;
+
+export const validationDirectivePolicyArgs = `\
+"""How to handle validation errors"""
+  policy: ValidateDirectivePolicy = RESOLVER`;
+
 export const testEasyDirective = <TValue>({
   createSchema,
   name,
   DirectiveVisitor,
   expectedArgsTypeDefs = '',
-  expectedUnknownTypeDefs = '',
+  expectedUnknownTypeDefs = validationDirectionEnumTypeDefs,
   testCases,
 }: {
   createSchema: CreateSchema<TValue>;
   name: string;
-  DirectiveVisitor: typeof EasyDirectiveVisitor;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DirectiveVisitor: any;
   expectedArgsTypeDefs?: string;
   expectedUnknownTypeDefs?: string;
   testCases: TestCase<TValue>[];
@@ -75,6 +88,7 @@ ${expectedDescription}\
 directive @${name}${expectedArgsTypeDefs} \
 on ${locationsStr}
 ${expectedUnknownTypeDefs}\
+
 `);
     });
 


### PR DESCRIPTION
This new arg will not hide an validation errors on
arguments and inputs in case they are nullable.
In such cases an valÃidation error will be thrown.
In order to do not break the API, this patch
will leave this new argument with a default value
which matches the previous behavior.

Closes #11