### PR TITLE
fix: remove dependency from apollo-server

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
         }
     },
     "rules": {
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["examples/*.*"]}],
         "import/extensions": ["error", "never"],
         "@typescript-eslint/consistent-type-assertions": [
             "error",

--- a/examples/access-control-directives.ts
+++ b/examples/access-control-directives.ts
@@ -1,4 +1,6 @@
-import { gql, makeExecutableSchema, ApolloServer } from 'apollo-server';
+import { ApolloServer } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 
 import { auth, hasPermissions, MissingPermissionsResolverInfo } from '../lib';
 

--- a/examples/value-validation-directives.ts
+++ b/examples/value-validation-directives.ts
@@ -1,4 +1,6 @@
-import { makeExecutableSchema, ApolloServer, gql } from 'apollo-server';
+import { ApolloServer } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 import { ValidationError } from 'apollo-server-errors';
 
 import { graphql, print, GraphQLResolveInfo } from 'graphql';

--- a/lib/EasyDirectiveVisitor.test.ts
+++ b/lib/EasyDirectiveVisitor.test.ts
@@ -10,7 +10,8 @@ import {
   GraphQLBoolean,
 } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 
 import EasyDirectiveVisitor from './EasyDirectiveVisitor';
 

--- a/lib/EasyDirectiveVisitor.ts
+++ b/lib/EasyDirectiveVisitor.ts
@@ -15,7 +15,8 @@ import {
   print,
   printType,
 } from 'graphql';
-import { gql, SchemaDirectiveVisitor } from 'apollo-server';
+import gql from 'graphql-tag';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
 
 export type ReadonlyGraphQLDirectiveConfigWithoutName = Readonly<
   {

--- a/lib/ValidateDirectiveVisitor.test.ts
+++ b/lib/ValidateDirectiveVisitor.test.ts
@@ -12,7 +12,8 @@ import {
   GraphQLResolveInfo,
 } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import ValidateDirectiveVisitor, {

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo, graphql } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 import { AuthenticationError } from 'apollo-server-errors';
 
 import AuthDirectiveVisitor from './auth';

--- a/lib/createValidateDirectiveVisitor.test.ts
+++ b/lib/createValidateDirectiveVisitor.test.ts
@@ -1,5 +1,6 @@
 import { graphql, GraphQLBoolean, GraphQLObjectType } from 'graphql';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 
 import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
 import ValidateDirectiveVisitor from './ValidateDirectiveVisitor';

--- a/lib/foreignNodeId.test.ts
+++ b/lib/foreignNodeId.test.ts
@@ -1,6 +1,7 @@
 import { graphql } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 import { ValidationError } from 'apollo-server-errors';
 
 import { ValidateFunction } from './ValidateDirectiveVisitor';

--- a/lib/hasPermissions.test.ts
+++ b/lib/hasPermissions.test.ts
@@ -7,7 +7,8 @@ import {
   GraphQLResolveInfo,
 } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
 import { ForbiddenError } from 'apollo-server-errors';
 
 import {

--- a/lib/listLength.test.ts
+++ b/lib/listLength.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLSchema } from 'graphql';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import listLength from './listLength';

--- a/lib/pattern.test.ts
+++ b/lib/pattern.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLSchema } from 'graphql';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import pattern from './pattern';

--- a/lib/range.test.ts
+++ b/lib/range.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLSchema } from 'graphql';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import range from './range';

--- a/lib/selfNodeId.test.ts
+++ b/lib/selfNodeId.test.ts
@@ -1,6 +1,7 @@
 import { graphql } from 'graphql';
 import { print } from 'graphql/language/printer';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import SelfNodeId from './selfNodeId';

--- a/lib/stringLength.test.ts
+++ b/lib/stringLength.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLSchema } from 'graphql';
-import { gql, makeExecutableSchema } from 'apollo-server';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 import { ValidationError } from 'apollo-server-errors';
 
 import stringLength from './stringLength';

--- a/lib/test-utils.test.ts
+++ b/lib/test-utils.test.ts
@@ -4,7 +4,7 @@ import {
   ExecutionResultDataDefault,
   ExecutionResult,
 } from 'graphql/execution/execute';
-import { gql } from 'apollo-server';
+import gql from 'graphql-tag';
 
 import EasyDirectiveVisitor from './EasyDirectiveVisitor';
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^26.0.7",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
-    "apollo-server": "^2.16.1",
+    "apollo-server": "^2.17.0",
     "eslint": "^7.5.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
@@ -56,8 +56,11 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "apollo-server": "^2.16.1",
     "apollo-server-errors": "^2.4.2",
     "graphql": "^14.7.0"
+  },
+  "dependencies": {
+    "graphql-tag": "^2.11.0",
+    "graphql-tools": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,10 +1268,10 @@ apollo-server-caching@^0.5.2:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.16.1.tgz#5b5b8245ab9c0cb6c2367ec19ab855dea6ccea3a"
-  integrity sha512-nuwn5ZBbmzPwDetb3FgiFFJlNK7ZBFg8kis/raymrjd3eBGdNcOyMTJDl6J9673X9Xqp+dXQmFYDW/G3G8S1YA==
+apollo-server-core@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.17.0.tgz#6af697ffe4968e74add01cd1efd2a8fb33299cf3"
+  integrity sha512-rjAkBbKSrGLDfg/g5bohnPlQahmkAxgEBuMDVsoF3aa+RaEPXPUMYrLbOxntl0LWeLbPiMa/IyFF43dvlGqV7w==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.3"
     "@apollographql/graphql-playground-html" "1.6.26"
@@ -1285,7 +1285,7 @@ apollo-server-core@^2.16.1:
     apollo-server-errors "^2.4.2"
     apollo-server-plugin-base "^0.9.1"
     apollo-server-types "^0.5.1"
-    apollo-tracing "^0.11.1"
+    apollo-tracing "^0.11.2"
     fast-json-stable-stringify "^2.0.0"
     graphql-extensions "^0.12.4"
     graphql-tag "^2.9.2"
@@ -1309,10 +1309,10 @@ apollo-server-errors@^2.4.2:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz#1128738a1d14da989f58420896d70524784eabe5"
   integrity sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==
 
-apollo-server-express@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.16.1.tgz#7438bca590ef8577d24d20ba0b6d582c120c0146"
-  integrity sha512-Oq5YNcaMYnRk6jDmA9LWf8oSd2KHDVe7jQ4wtooAvG9FVUD+FaFBgSkytXHMvtifQh2wdF07Ri8uDLMz6IQjTw==
+apollo-server-express@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.17.0.tgz#2014559b75a0bcf7ff8cf0f2d077da6653abbc18"
+  integrity sha512-PonpWOuM1DH3Cz0bu56Tusr3GXOnectC6AD/gy2GXK0v84E7tKTuxEY3SgsgxhvfvvhfwJbXTyIogL/wezqnCw==
   dependencies:
     "@apollographql/graphql-playground-html" "1.6.26"
     "@types/accepts" "^1.3.5"
@@ -1320,7 +1320,7 @@ apollo-server-express@^2.16.1:
     "@types/cors" "^2.8.4"
     "@types/express" "4.17.7"
     accepts "^1.3.5"
-    apollo-server-core "^2.16.1"
+    apollo-server-core "^2.17.0"
     apollo-server-types "^0.5.1"
     body-parser "^1.18.3"
     cors "^2.8.4"
@@ -1347,21 +1347,21 @@ apollo-server-types@^0.5.1:
     apollo-server-caching "^0.5.2"
     apollo-server-env "^2.4.5"
 
-apollo-server@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-2.16.1.tgz#edc319606eb29f73132239bdc005dd88ac40a142"
-  integrity sha512-oy9NVRzGwlpQ+W1DwLKRH+KASmodSYpvYIRY5DMAZtGqNmT2zOCpbIZVjBt23SuPB5NhIhhE4ROzoObRv3zy5w==
+apollo-server@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-2.17.0.tgz#d015fe6d8d6bdd468bc43ecabcb29ceb41e0b286"
+  integrity sha512-vVMu+VqjmsB6yk5iNTb/AXM6EJGd2uwzrcTAbwqvGI7GqCYDRZlGBwrQCjOU/jT/EPWdNRWks/qhJYiQMeVXSg==
   dependencies:
-    apollo-server-core "^2.16.1"
-    apollo-server-express "^2.16.1"
+    apollo-server-core "^2.17.0"
+    apollo-server-express "^2.17.0"
     express "^4.0.0"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"
 
-apollo-tracing@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.11.1.tgz#3e3a4ce4b21e57dcc57b10bbd539db243b752606"
-  integrity sha512-l7g+uILw7v32GA46IRXIx5XXbZhFI96BhSqrGK9yyvfq+NMcvVZrj3kIhRImPGhAjMdV+5biA/jztabElAbDjg==
+apollo-tracing@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.11.2.tgz#14308b176e021f5e6ec3ee670f8f96e9fbfdb50c"
+  integrity sha512-QjmRd2ozGD+PfmF6U9w/w6jrclYSBNczN6Bzppr8qA5somEGl5pqdprIZYL28H0IapZiutA3x6p6ZVF/cVX8wA==
   dependencies:
     apollo-server-env "^2.4.5"
     apollo-server-plugin-base "^0.9.1"
@@ -3017,6 +3017,11 @@ graphql-subscriptions@^1.0.0:
   integrity sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==
   dependencies:
     iterall "^1.2.1"
+
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
 graphql-tag@^2.9.2:
   version "2.10.3"


### PR DESCRIPTION
People using non-standalone (apollo-server-express, apollo-server-lambda, etc.)
versions of apollo-server would get an import error if they to use this library, since
they do not install the apollo-server package.
In order to fix this problem this commit uses graphql-tag and
graphql-tools directly ditching the apollo-server dependency.

Closes #24 #20