### PR TITLE
fix: validation error on output when value is optional

### DIFF
--- a/lib/ValidateDirectiveVisitor.ts
+++ b/lib/ValidateDirectiveVisitor.ts
@@ -551,7 +551,7 @@ export const wrapFieldResolverResult = <TContext>(
   field.resolve = async function (...args): Promise<unknown> {
     const originalValue = await resolve.apply(this, args);
     const validatedValue = validate(originalValue, type, objectType, args[2]);
-    if (validatedValue === undefined) {
+    if (validatedValue === undefined && validatedValue !== originalValue) {
       // mimics `GraphQLScalarType.serialize()` behavior
       throw new ValidationError('validation returned undefined');
     }


### PR DESCRIPTION
When a optional output value is requested in a query and its value is null we receive a "validation returned undefined" error.

This validation error should only occur when the original value is different from undefined/null and the validated value is undefined/null.