### PR TITLE
feat: expose `validation` error extension

### DIFF
--- a/examples/value-validation-directives.ts
+++ b/examples/value-validation-directives.ts
@@ -60,6 +60,9 @@ const yourTypeDefs = [
       listLengthExample(
         arg: [Int] @listLength(min: 1, max: 100)
       ): ListLengthExample
+      throwingIntRangeExample(
+        arg: Int @range(min: -10, max: 10, policy: THROW)
+      ): IntRangeExample
     }
   `,
 ];
@@ -79,6 +82,7 @@ const schema = makeExecutableSchema({
       listLengthExample: argsResolver,
       patternExample: argsResolver,
       stringLengthExample: argsResolver,
+      throwingIntRangeExample: argsResolver,
     },
   },
   schemaDirectives: { listLength, pattern, range, stringLength },
@@ -251,6 +255,45 @@ const tests = {
         },
       },
     },
+  },
+  Throwing: {
+    query: gql`
+      query Throwing {
+        throwingIntRangeExample(arg: 100) {
+          arg
+          validationErrors {
+            message
+            path
+          }
+        }
+      }
+    `,
+    result: {
+      // keep same order as in GQL so JSON.stringify() serializes the same
+      /* eslint-disable sort-keys */
+      errors: [
+        {
+          message: 'More than 10',
+          locations: [
+            {
+              line: 2,
+              column: 3,
+            },
+          ],
+          path: ['throwingIntRangeExample'],
+          extensions: {
+            code: 'GRAPHQL_VALIDATION_FAILED',
+            validation: {
+              path: ['arg'],
+            },
+          },
+        },
+      ],
+      data: {
+        throwingIntRangeExample: null,
+      },
+    },
+    /* eslint-enable sort-keys */
   },
 };
 

--- a/lib/ValidateDirectiveVisitor.test.ts
+++ b/lib/ValidateDirectiveVisitor.test.ts
@@ -8,7 +8,6 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
-  GraphQLError,
   GraphQLResolveInfo,
 } from 'graphql';
 import { print } from 'graphql/language/printer';
@@ -122,9 +121,17 @@ type ValidatedInputErrorOutput {
     class TestDirective extends ValidateDirectiveVisitor<TestDirectiveArgs> {
       // eslint-disable-next-line class-methods-use-this
       public getValidationForArgs(): ValidateFunction {
-        return (): void => {
+        const validate = (): void => {
           throw new ValidationError('Validation error');
         };
+        Object.defineProperty(validate, 'validateProperties', {
+          value: {
+            args: this.args,
+            directive: 'testThrowPolicyValidate',
+          },
+          writable: false,
+        });
+        return validate;
       }
     }
     const schema = ValidateDirectiveVisitor.addValidationResolversToSchema(
@@ -167,7 +174,26 @@ type ValidatedInputErrorOutput {
       const result = await graphql(schema, source);
       expect(result).toEqual({
         data: null,
-        errors: [new GraphQLError('Validation error')],
+        errors: [
+          {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+              validation: {
+                path: ['arg'],
+                properties: {
+                  args: {
+                    policy: 'THROW',
+                    validate: true,
+                  },
+                  directive: 'testThrowPolicyValidate',
+                },
+              },
+            },
+            locations: [{ column: 3, line: 2 }],
+            message: 'Validation error',
+            path: ['argShouldFail'],
+          },
+        ],
       });
     });
 
@@ -180,7 +206,26 @@ type ValidatedInputErrorOutput {
       const result = await graphql(schema, source);
       expect(result).toEqual({
         data: null,
-        errors: [new GraphQLError('Validation error')],
+        errors: [
+          {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+              validation: {
+                path: ['input', 'n'],
+                properties: {
+                  args: {
+                    policy: 'THROW',
+                    validate: true,
+                  },
+                  directive: 'testThrowPolicyValidate',
+                },
+              },
+            },
+            locations: [{ column: 3, line: 2 }],
+            message: 'Validation error',
+            path: ['failInputField'],
+          },
+        ],
       });
     });
 
@@ -193,7 +238,26 @@ type ValidatedInputErrorOutput {
       const result = await graphql(schema, source);
       expect(result).toEqual({
         data: null,
-        errors: [new GraphQLError('Validation error')],
+        errors: [
+          {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+              validation: {
+                path: ['input', 'n'],
+                properties: {
+                  args: {
+                    policy: 'THROW',
+                    validate: true,
+                  },
+                  directive: 'testThrowPolicyValidate',
+                },
+              },
+            },
+            locations: [{ column: 3, line: 2 }],
+            message: 'Validation error',
+            path: ['failInput'],
+          },
+        ],
       });
     });
   });

--- a/lib/createValidateDirectiveVisitor.ts
+++ b/lib/createValidateDirectiveVisitor.ts
@@ -51,6 +51,18 @@ const createValidateDirectiveVisitor = <TArgs extends ValidationDirectiveArgs>({
 
     public getValidationForArgs(): ValidateFunction | undefined {
       const validate = createValidate(this.args);
+      if (
+        typeof validate === 'function' &&
+        !('validateProperties' in validate)
+      ) {
+        Object.defineProperty(validate, 'validateProperties', {
+          value: {
+            args: this.args,
+            directive: defaultName,
+          },
+          writable: false,
+        });
+      }
       return isValidateArrayOrValue ? validateArrayOrValue(validate) : validate;
     }
   }


### PR DESCRIPTION
This error extension will allow one to know exactly what failed,
providing further `path` and `properties`, that can let the caller
(ie: Graphical User Interface) to properly map to the UI element (ie:
form entry).

It will use `validateProperties` function attribute in order to
enhance with more information. `createValidateDirectiveVisitor()` will
automatically set that based on the directive name and the arguments.

Example:
```js
        errors: [
          {
            extensions: {
              code: 'GRAPHQL_VALIDATION_FAILED',
              validation: {
                path: ['arg'],  // <--- always present (argument that failed)
                properties: {   // <--- present if validateProperties exists in validate()
                  args: {
                    policy: 'THROW',
                    validate: true,
                  },
                  directive: 'testThrowPolicyValidate',
                },
              },
            },
            locations: [{ column: 3, line: 2 }],
            message: 'Validation error',
            path: ['argShouldFail'], // <--- GraphQL standard, the field that failed
          },
        ],
```

Closes #35 