### PR TITLE
fix: allow permission validation to be skipped on null

### DIFF
--- a/lib/ValidateDirectiveVisitor.ts
+++ b/lib/ValidateDirectiveVisitor.ts
@@ -17,6 +17,7 @@ import {
   GraphQLScalarType,
   GraphQLSchema,
   GraphQLString,
+  DirectiveLocationEnum,
 } from 'graphql';
 import { ValidationError } from 'apollo-server-errors';
 
@@ -889,9 +890,9 @@ abstract class ValidateDirectiveVisitor<
    *  - `null` for nullable fields;
    *  - `Array` for list fields.
    */
-  public abstract getValidationForArgs():
-    | ValidateFunction<TContext>
-    | undefined;
+  public abstract getValidationForArgs(
+    location: DirectiveLocationEnum,
+  ): ValidateFunction<TContext> | undefined;
 
   // Arguments directly annotated with the directive, such as
   //
@@ -903,7 +904,9 @@ abstract class ValidateDirectiveVisitor<
     argument: GraphQLArgument,
     { field }: { field: GraphQLField<unknown, unknown> },
   ): void {
-    const validate = this.getValidationForArgs();
+    const validate = this.getValidationForArgs(
+      DirectiveLocation.ARGUMENT_DEFINITION,
+    );
     if (!validate) {
       return;
     }
@@ -936,7 +939,7 @@ abstract class ValidateDirectiveVisitor<
   // This is done with `addValidationResolversToSchema()`.
 
   public visitInputObject(object: GraphQLInputObjectType): void {
-    const validate = this.getValidationForArgs();
+    const validate = this.getValidationForArgs(DirectiveLocation.INPUT_OBJECT);
     if (!validate) return;
     const { policy } = this.args;
     Object.values(object.getFields()).forEach(field => {
@@ -952,7 +955,9 @@ abstract class ValidateDirectiveVisitor<
       objectType: GraphQLInputObjectType;
     },
   ): void {
-    const validate = this.getValidationForArgs();
+    const validate = this.getValidationForArgs(
+      DirectiveLocation.INPUT_FIELD_DEFINITION,
+    );
     if (!validate) return;
     const { policy } = this.args;
     addContainerEntryValidation(objectType, field, validate, policy);
@@ -970,7 +975,9 @@ abstract class ValidateDirectiveVisitor<
       objectType: GraphQLObjectType;
     },
   ): void {
-    const validate = this.getValidationForArgs();
+    const validate = this.getValidationForArgs(
+      DirectiveLocation.FIELD_DEFINITION,
+    );
     if (!validate) return;
     if (this.applyValidationToOutputTypesAfterOriginalResolver) {
       setFieldResolveToApplyOriginalResolveAndThenValidateResult(
@@ -988,7 +995,7 @@ abstract class ValidateDirectiveVisitor<
   }
 
   public visitObject(object: GraphQLObjectType | GraphQLInterfaceType): void {
-    const validate = this.getValidationForArgs();
+    const validate = this.getValidationForArgs(DirectiveLocation.OBJECT);
     if (!validate) return;
     Object.values(object.getFields()).forEach(field => {
       if (this.applyValidationToOutputTypesAfterOriginalResolver) {

--- a/lib/hasPermissions.test.ts
+++ b/lib/hasPermissions.test.ts
@@ -307,10 +307,16 @@ enum HasPermissionsDirectivePolicy {
                 @${name}(permissions: ["x", "y"], policy: RESOLVER)
               publicField: String
               alsoPublic: String @${name}(permissions: [])
+              skipOnNullField: String @${name}(permissions: ["I don't have this permission, but hey I'm not providing the input so it should not care"])
+              notProvidedField: String @${name}(permissions: ["I love permissions"])
+            }
+
+            input SecondInput @${name}(permissions: ["no permission to use this input"]) {
+              number: Int
             }
 
             type Query {
-              test(arg: InputObject): String
+              test(arg: InputObject, arg2: SecondInput, number: Int @${name}(permissions: ["no permission to use this argument"])): String
             }
           `,
           ],
@@ -324,6 +330,7 @@ enum HasPermissionsDirectivePolicy {
               email: "user@server.com"
               onlyAllowedMayRead: 42
               publicField: "hello"
+              skipOnNullField: null
             }
           )
         }
@@ -348,6 +355,7 @@ enum HasPermissionsDirectivePolicy {
               email: 'user@server.com',
               onlyAllowedMayRead: 42,
               publicField: 'hello',
+              skipOnNullField: null,
             },
           },
           context,
@@ -389,6 +397,7 @@ enum HasPermissionsDirectivePolicy {
               email: 'user@server.com',
               onlyAllowedMayRead: 42,
               publicField: 'hello',
+              skipOnNullField: null,
             },
           },
           context,


### PR DESCRIPTION
This commit adds a new argument for the @hasPermissions directive,
which allows the permission check to be skipped in case the
input/type value is null or undefined.
This type of check if useful for when @hasPermissions is
used on optinal fields in a input, thus leaving room for
one to continue to use the input even though he/she
may not have the permission to use that field.