### PR TITLE
feat: add trim directive

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,4 +16,5 @@ export { default as stringLength } from './stringLength';
 export { default as selfNodeId } from './selfNodeId';
 export { default as foreignNodeId } from './foreignNodeId';
 export { default as cleanupPattern } from './cleanupPattern';
+export { default as trim } from './trim';
 export type { MissingPermissionsResolverInfo } from './hasPermissions';

--- a/lib/trim.test.ts
+++ b/lib/trim.test.ts
@@ -1,0 +1,167 @@
+import { GraphQLSchema } from 'graphql';
+import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
+
+import trim, {
+  createValidate as createTrimDirectiveValidate,
+  DEFAULT_TRIM_MODE,
+  trimDirectiveSchemaEnumName,
+  TrimMode,
+} from './trim';
+import capitalize from './capitalize';
+
+import {
+  CreateSchemaConfig,
+  ExpectedTestResult,
+  TestCase,
+  testEasyDirective,
+  validationDirectionEnumTypeDefs,
+  validationDirectivePolicyArgs,
+} from './test-utils.test';
+import { ValidateDirectivePolicy } from './ValidateDirectiveVisitor';
+
+type RootValue = {
+  arrayTest?: (string | null)[] | null;
+  test?: string | null;
+  number?: number;
+  bool?: boolean;
+  obj?: { toString(): string };
+};
+
+const createSchema = ({
+  name,
+  testCase: { directiveArgs },
+}: CreateSchemaConfig<RootValue>): GraphQLSchema =>
+  trim.addValidationResolversToSchema(
+    makeExecutableSchema({
+      schemaDirectives: { [name]: trim },
+      typeDefs: [
+        ...trim.getTypeDefs(name, undefined, true, true),
+        gql`
+                type Query {
+                  test: String @${name}${directiveArgs}
+                }
+              `,
+      ],
+    }),
+  );
+
+const name = 'trim';
+
+const expectedResult = (
+  value: string,
+  key: keyof RootValue = 'test',
+): ExpectedTestResult<RootValue> => ({
+  data: { [key]: value },
+});
+
+const stringToTrim =
+  '  \r\n  \n  \t \r string with whitespaces at both start and end \n \r \r\n \t ';
+
+const noTrimmableWhitespaces = 'No Spaces';
+
+const whiteSpacesAtTheEnd = 'White spaces at the end \n  \r  \r\n \t';
+
+const whiteSpacesAtTheStart = ' \r \r\n \t \n White spaces at the start';
+
+const generateTestCase: (
+  value: string,
+  trimFn: (stringToTrim: string) => string,
+) => NonNullable<TestCase<RootValue>['tests']>[0] = (value, trimFn) => ({
+  expected: expectedResult(trimFn(value)),
+  rootValue: { test: value },
+});
+
+const trimAll = (value: { toString: () => string }): string =>
+  value.toString().trim();
+
+const trimEnd = (value: { toString: () => string }): string =>
+  value.toString().trimRight();
+
+const trimStart = (value: { toString: () => string }): string =>
+  value.toString().trimLeft();
+
+describe('directive @trim error tests', () => {
+  // this should never happen due to schema validation, but is added to achieve 100% coverage
+  it.each([
+    [ValidateDirectivePolicy.RESOLVER],
+    [ValidateDirectivePolicy.THROW],
+  ])('should throw an error when "mode" is invalid - policy: %s', policy => {
+    const invalidMode = 'INVALID_MODE' as TrimMode;
+    try {
+      createTrimDirectiveValidate({
+        mode: invalidMode,
+        policy,
+      });
+      expect(true).toBeFalsy();
+    } catch (err) {
+      expect(err).toEqual(
+        new TypeError(
+          `The value ${invalidMode} is not accepted by this argument`,
+        ),
+      );
+    }
+  });
+});
+
+testEasyDirective({
+  createSchema,
+  DirectiveVisitor: trim,
+  expectedArgsTypeDefs: `\
+(
+  mode: ${trimDirectiveSchemaEnumName}! = ${DEFAULT_TRIM_MODE}
+  ${validationDirectivePolicyArgs(capitalize(name))}
+)`,
+  expectedUnknownTypeDefs: `enum ${trimDirectiveSchemaEnumName} {
+  """The value of this field will have both start and end of the string trimmed"""
+  ${TrimMode.TRIM_ALL}
+  """The value of this field will have only the end of the string trimmed"""
+  ${TrimMode.TRIM_END}
+  """The value of this field will have only the start of the string trimmed"""
+  ${TrimMode.TRIM_START}
+}
+${validationDirectionEnumTypeDefs(capitalize(name))}`,
+  name,
+  testCases: [
+    {
+      directiveArgs: `(mode: ${TrimMode.TRIM_ALL} )`,
+      operation: '{ test }',
+      tests: [
+        generateTestCase(noTrimmableWhitespaces, trimAll),
+        generateTestCase(stringToTrim, trimAll),
+        generateTestCase(whiteSpacesAtTheEnd, trimAll),
+        generateTestCase(whiteSpacesAtTheStart, trimAll),
+      ],
+    },
+    {
+      directiveArgs: '',
+      operation: '{ test }',
+      tests: [
+        generateTestCase(noTrimmableWhitespaces, trimAll),
+        generateTestCase(stringToTrim, trimAll),
+        generateTestCase(whiteSpacesAtTheEnd, trimAll),
+        generateTestCase(whiteSpacesAtTheStart, trimAll),
+      ],
+    },
+    {
+      directiveArgs: `(mode: ${TrimMode.TRIM_END})`,
+      operation: '{ test }',
+      tests: [
+        generateTestCase(noTrimmableWhitespaces, trimEnd),
+        generateTestCase(stringToTrim, trimEnd),
+        generateTestCase(whiteSpacesAtTheEnd, trimEnd),
+        generateTestCase(whiteSpacesAtTheStart, trimEnd),
+      ],
+    },
+    {
+      directiveArgs: `(mode: ${TrimMode.TRIM_START})`,
+      operation: '{ test }',
+      tests: [
+        generateTestCase(noTrimmableWhitespaces, trimStart),
+        generateTestCase(stringToTrim, trimStart),
+        generateTestCase(whiteSpacesAtTheEnd, trimStart),
+        generateTestCase(whiteSpacesAtTheStart, trimStart),
+      ],
+    },
+  ],
+});

--- a/lib/trim.ts
+++ b/lib/trim.ts
@@ -1,0 +1,83 @@
+import { GraphQLEnumType, GraphQLNonNull } from 'graphql';
+
+import {
+  ValidateFunction,
+  ValidationDirectiveArgs,
+} from './ValidateDirectiveVisitor';
+import createValidateDirectiveVisitor from './createValidateDirectiveVisitor';
+import neverAssertion from './utils/neverAssertion';
+import createPatternHandler from './patternCommon';
+
+export enum TrimMode {
+  TRIM_ALL = 'TRIM_ALL',
+  TRIM_END = 'TRIM_END',
+  TRIM_START = 'TRIM_START',
+}
+
+export const DEFAULT_TRIM_MODE = TrimMode.TRIM_ALL;
+
+export const trimDirectiveSchemaEnumName = 'TrimDirectiveMode';
+
+type TrimDirectiveArgs = ValidationDirectiveArgs & { mode: TrimMode };
+
+const trimAllHandler = createPatternHandler((value: string): string =>
+  value.trim(),
+);
+
+const trimEndHandler = createPatternHandler((value: string): string =>
+  value.trimRight(),
+);
+
+const trimStartHandler = createPatternHandler((value: string): string =>
+  value.trimLeft(),
+);
+
+export const createValidate = ({
+  mode,
+}: TrimDirectiveArgs): ValidateFunction => {
+  switch (mode) {
+    case TrimMode.TRIM_ALL:
+      return trimAllHandler;
+    case TrimMode.TRIM_END:
+      return trimEndHandler;
+    case TrimMode.TRIM_START:
+      return trimStartHandler;
+    default:
+      return neverAssertion(mode);
+  }
+};
+
+export default createValidateDirectiveVisitor({
+  createValidate,
+  defaultName: 'trim',
+  directiveConfig: {
+    args: {
+      mode: {
+        defaultValue: DEFAULT_TRIM_MODE,
+        type: new GraphQLNonNull(
+          new GraphQLEnumType({
+            name: trimDirectiveSchemaEnumName,
+            values: {
+              [TrimMode.TRIM_ALL]: {
+                description:
+                  'The value of this field will have both start and end of the string trimmed',
+                value: TrimMode.TRIM_ALL,
+              },
+              [TrimMode.TRIM_END]: {
+                description:
+                  'The value of this field will have only the end of the string trimmed',
+                value: TrimMode.TRIM_END,
+              },
+              [TrimMode.TRIM_START]: {
+                description:
+                  'The value of this field will have only the start of the string trimmed',
+                value: TrimMode.TRIM_START,
+              },
+            },
+          }),
+        ),
+      },
+    },
+    description: 'trims a string based on the selected mode',
+  },
+});

--- a/lib/utils/neverAssertion.ts
+++ b/lib/utils/neverAssertion.ts
@@ -1,0 +1,4 @@
+const neverAssertion = (value: never): never => {
+  throw new TypeError(`The value ${value} is not accepted by this argument`);
+};
+export default neverAssertion;


### PR DESCRIPTION
This directive will remove trailing whitespace characters from the start of the string, from the end of the string or both based on the `mode` argument