### PR TITLE
Fix/directives not applied to type args

### DIFF
--- a/lib/createSchemaMapperForVisitor.ts
+++ b/lib/createSchemaMapperForVisitor.ts
@@ -2,6 +2,7 @@ import type { SchemaMapper } from '@graphql-tools/utils';
 import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
 import type {
   DirectiveLocation,
+  GraphQLArgument,
   GraphQLFieldConfig,
   GraphQLObjectType,
   GraphQLSchema,
@@ -26,6 +27,17 @@ export const createMapper = <T extends DirectiveLocation>(
     return mutation;
   },
   [MapperKind.OBJECT_TYPE](type, schema): GraphQLObjectType {
+    Object.values(type.getFields()).forEach(field => {
+      field.args.forEach(arg => {
+        const [directive] = getDirective(schema, arg, directiveName) ?? [];
+        if (!directive) return;
+        // eslint-disable-next-line no-param-reassign
+        visitor.args = directive;
+        visitor.visitArgumentDefinition(arg as GraphQLArgument, {
+          field,
+        });
+      });
+    });
     const [directive] = getDirective(schema, type, directiveName) ?? [];
     if (!directive) return type;
     // eslint-disable-next-line no-param-reassign

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profusion/apollo-validation-directives",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "GraphQL directives to implement field validations in Apollo Server",
   "author": "Gustavo Sverzut Barbieri <barbieri@profusion.mobi>",
   "license": "MIT",


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Fix a problem that directives are not applied to type fields with arguments using directives.

Eg: `foreignNodeId` wasn't being applied to posts resolver

```gql
type User {
  posts(
    categories: [ID] @foreignNodeId(typename: 'Post')
  ): [Posts]
}
type Query {
  ...
}
```

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

## Visual reference

<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
